### PR TITLE
Added support of factalshades __version__ attr

### DIFF
--- a/dev_notes.txt
+++ b/dev_notes.txt
@@ -24,3 +24,8 @@ calc = mandelbrot.full_calc(*calc_args, **calc_kwargs)
 plotter = fs.Fractal_plotter(calc, ****)
 
 plotter.explore()
+
+________________________________________
+Compile
+https://nuitka.net/pages/download.html
+https://sametmax.com/vive-setup-cfg-et-mort-a-pyproject-toml/

--- a/install_from_local.sh
+++ b/install_from_local.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Dev mode installation : force reinstall
-python3 -m pip install --force-reinstall ./dist/fractalshades_G_BILLOTEY-0.0.1-py3-none-any.whl
+python3 -m pip install --force-reinstall ./dist/fractalshades_G_BILLOTEY-0.0.2-py3-none-any.whl

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = fractalshades-G_BILLOTEY
-version = 0.0.1
+version = attr: fractalshades.__version__
 author = Geoffroy Billotey
 author_email = geoffroy.billotey@gmail.com
 description = Fractal deep-zoom explorer for Mandelbrot fractal - and more to come...

--- a/src/fractalshades/__init__.py
+++ b/src/fractalshades/__init__.py
@@ -1,3 +1,5 @@
 # -*- coding: utf-8 -*-
 from .core import *
 from .perturbation import *
+
+__version__ = "0.0.2"

--- a/tests/test_perturbation.py
+++ b/tests/test_perturbation.py
@@ -71,7 +71,7 @@ class Test_Perturbation_mandelbrot(unittest.TestCase):
                 ref_file = os.path.join(self.image_dir_ref, test_name + ".png")
                 err = compare_png(ref_file, test_file)
                 self.assertTrue(err < 0.01)
-    
+
     @test_config.no_stdout
     def test_M2_int_E11(self):
         """
@@ -95,9 +95,9 @@ class Test_Perturbation_mandelbrot(unittest.TestCase):
                 ref_file = os.path.join(self.image_dir_ref, test_name + ".png")
                 err = compare_png(ref_file, test_file)
                 self.assertTrue(err < 0.01)
-                
 
-    #@test_config.no_stdout
+
+    @test_config.no_stdout
     def test_M2_antialias_E0(self):
         """
         Testing field lines, and antialiasing. Full Mandelbrot


### PR DESCRIPTION

ref : https://packaging.python.org/guides/single-sourcing-package-version/

As of the release of setuptools 46.4.0, one can accomplish the same thing by instead placing the following in the project’s setup.cfg file (replacing “package” with the import name of the package):

[metadata]
version = attr: package.__version__

